### PR TITLE
ci: bump super-linter to v8.0.0

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -36,20 +36,13 @@ jobs:
         run: npm ci
 
       - name: Lint Codebase
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@v8.0.0
         env:
           DEFAULT_BRANCH: main
           FILTER_REGEX_EXCLUDE: dist/**/*
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: ${{ github.workspace }}
           TYPESCRIPT_DEFAULT_STYLE: prettier
-          VALIDATE_TYPESCRIPT_STANDARD: false
-          VALIDATE_TYPESCRIPT_ES: false
-          VALIDATE_JAVASCRIPT_ES: false
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_JSCPD: false
           VALIDATE_JSON: false
-
-      - name: Run ESLint
-        if: always()
-        run: npm run lint


### PR DESCRIPTION
- supported eslint v9
- dropped typescript standard